### PR TITLE
Add keybind to toggle the menu & option to remember last opened page

### DIFF
--- a/PluginConfigurator/API/ConfigDivision.cs
+++ b/PluginConfigurator/API/ConfigDivision.cs
@@ -88,8 +88,8 @@ namespace PluginConfig.API
                 if (currentVirtualPanel != null)
                     currentVirtualPanel.gameObject.SetActive(!hidden && !parentHidden);
 
-                foreach (ConfigField field in fields)
-                    field.parentHidden = value || (hidden || parentHidden);
+                foreach (ConfigField cfield in fields)
+                    cfield.parentHidden = value || (hidden || parentHidden);
             }
         }
 
@@ -97,9 +97,9 @@ namespace PluginConfig.API
             set 
             {
                 base.interactable = value;
-                foreach (ConfigField field in fields)
+                foreach (ConfigField cfield in fields)
                 {
-                    field.parentInteractable = value && (interactable && parentInteractable);
+                    cfield.parentInteractable = value && (interactable && parentInteractable);
                 }
             }
         }

--- a/PluginConfigurator/API/ConfigPanel.cs
+++ b/PluginConfigurator/API/ConfigPanel.cs
@@ -98,7 +98,7 @@ namespace PluginConfig.API
 			currentConfig.presetButtonCanBeShown = false;
 			currentConfig.presetMenuButton.gameObject.SetActive(false);
 
-            if (PluginConfiguratorController.activePanel == gameObject)
+            if (!PluginConfiguratorController.rememberConfigPage.value && PluginConfiguratorController.activePanel == gameObject)
                 PluginConfiguratorController.activePanel = null;
 
             try

--- a/PluginConfigurator/Patches/UnpausePatch.cs
+++ b/PluginConfigurator/Patches/UnpausePatch.cs
@@ -5,12 +5,14 @@ namespace PluginConfig.Patches
     [HarmonyPatch(typeof(OptionsManager), nameof(OptionsManager.CloseOptions))]
     public class CloseOptionsPatch
     {
+        internal static bool bypassBlock = false;
+
         static bool Prefix(OptionsManager __instance)
         {
             if (PluginConfiguratorController.activePanel == null || !PluginConfiguratorController.activePanel.activeSelf)
                 return true;
 
-            if (PluginConfiguratorController.activePanel != null && PluginConfiguratorController.activePanel != PluginConfiguratorController.mainPanel.gameObject)
+            if (!bypassBlock && PluginConfiguratorController.activePanel != null && PluginConfiguratorController.activePanel != PluginConfiguratorController.mainPanel.gameObject)
                 return false;
 
             return true;

--- a/PluginConfigurator/PluginConfiguratorController.cs
+++ b/PluginConfigurator/PluginConfiguratorController.cs
@@ -791,7 +791,7 @@ namespace PluginConfig
 					activePanel.SetActive(false); // Idk why but gotta do this for CloseOptions to work
 					OptionsManager.Instance.CloseOptions();
 					OptionsManager.Instance.UnPause();
-					activePanel.SetActive(true); // Revert the above SetActive or we'll get a blank screen when entering options
+					activePanel?.SetActive(true); // Revert the above SetActive or we'll get a blank screen when entering options
 				}
 				else
 				{

--- a/PluginConfigurator/PluginConfiguratorController.cs
+++ b/PluginConfigurator/PluginConfiguratorController.cs
@@ -137,7 +137,7 @@ namespace PluginConfig
 		internal static GameObject activePanel;
 		internal static Button backButton;
 
-		private static void SelectPluginConfigInOptions()
+		private static void SelectPluginConfigInOptions(bool forceMainPanelFallback = false)
 		{
 			Transform panel = optionsMenu.transform.Find("Navigation Rail");
 			Transform pages = optionsMenu.transform.Find("Pages");
@@ -180,10 +180,15 @@ namespace PluginConfig
 			}
 			else
 			{
-				if (activePanel != null) 
+				if (activePanel != null && !activePanel.activeInHierarchy)
+				{
 					activePanel.SetActive(true);
-				else 
+				}
+				else if (activePanel == null || (forceMainPanelFallback && activePanel != mainPanel.gameObject))
+				{
+					activePanel?.SetActive(false);
 					mainPanel.gameObject.SetActive(true);
+				}
 			}
 		}
 
@@ -240,7 +245,7 @@ namespace PluginConfig
 			Button pluginConfigButton = pluginConfigObj.GetComponent<Button>();
 			pluginConfigObj.transform.SetSiblingIndex(0);
 
-			pluginConfigButton.onClick.AddListener(SelectPluginConfigInOptions);
+			pluginConfigButton.onClick.AddListener(() => SelectPluginConfigInOptions(forceMainPanelFallback: true));
 
 			mainPanel = Addressables.InstantiateAsync(ASSET_PATH_CONFIG_PANEL, pages).WaitForCompletion().GetComponent<ConfigPanelConcrete>();
 			mainPanel.gameObject.AddComponent<MainPanelComponent>();

--- a/PluginConfigurator/PluginConfiguratorController.cs
+++ b/PluginConfigurator/PluginConfiguratorController.cs
@@ -792,10 +792,10 @@ namespace PluginConfig
 			{
 				if (activePanel != null && activePanel.activeInHierarchy)
 				{
-					activePanel.SetActive(false); // Idk why but gotta do this for CloseOptions to work
+					CloseOptionsPatch.bypassBlock = true;
 					OptionsManager.Instance.CloseOptions();
+					CloseOptionsPatch.bypassBlock = false;
 					OptionsManager.Instance.UnPause();
-					activePanel?.SetActive(true); // Revert the above SetActive or we'll get a blank screen when entering options
 				}
 				else
 				{

--- a/PluginConfigurator/PluginConfiguratorController.cs
+++ b/PluginConfigurator/PluginConfiguratorController.cs
@@ -185,10 +185,16 @@ namespace PluginConfig
 				}
 				else if (activePanel == null || (forceMainPanelFallback && activePanel != mainPanel.gameObject))
 				{
-					activePanel?.SetActive(false);
+					if (activePanel != null) activePanel.SetActive(false);
 					mainPanel.gameObject.SetActive(true);
 				}
 			}
+		}
+
+		private IEnumerator SelectPluginConfigInOptionsNextFrame()
+        {
+			yield return null;
+			SelectPluginConfigInOptions();
 		}
 
 		private IEnumerator loadObjectAsync(Transform panel)
@@ -801,7 +807,7 @@ namespace PluginConfig
 				{
 					OptionsManager.Instance.Pause();
 					OptionsManager.Instance.OpenOptions();
-					SelectPluginConfigInOptions();
+					StartCoroutine(SelectPluginConfigInOptionsNextFrame());
 				}
 			}
 		}

--- a/PluginConfigurator/PluginConfiguratorController.cs
+++ b/PluginConfigurator/PluginConfiguratorController.cs
@@ -175,7 +175,6 @@ namespace PluginConfig
 
 					activePanel.SetActive(false);
 				}
-				activePanel = null;
 				mainPanel.gameObject.SetActive(true);
 			}
 			else

--- a/PluginConfigurator/PluginConfiguratorController.cs
+++ b/PluginConfigurator/PluginConfiguratorController.cs
@@ -52,7 +52,7 @@ namespace PluginConfig
 
 		void OnDisable()
 		{
-			if (PluginConfiguratorController.activePanel == gameObject)
+			if (!PluginConfiguratorController.rememberConfigPage.value && PluginConfiguratorController.activePanel == gameObject)
 				PluginConfiguratorController.activePanel = null;
         }
 	}
@@ -132,9 +132,60 @@ namespace PluginConfig
 		}
 
 		internal static Transform optionsMenu;
+		internal static GameObject pluginConfigObj;
 		internal static ConfigPanelConcrete mainPanel;
 		internal static GameObject activePanel;
 		internal static Button backButton;
+
+		private static void SelectPluginConfigInOptions()
+		{
+			Transform panel = optionsMenu.transform.Find("Navigation Rail");
+			Transform pages = optionsMenu.transform.Find("Pages");
+
+			ButtonHighlightParent highlightParent = panel.GetComponent<ButtonHighlightParent>();
+			Image buttonImage = pluginConfigObj.GetComponent<Image>();
+			if (highlightParent != null && buttonImage != null) highlightParent.ChangeButton(buttonImage);
+
+			foreach (Transform t in UnityUtils.GetChilds(pages).Concat(UnityUtils.GetChilds(panel)))
+			{
+				if (t == mainPanel.transform || t == pluginConfigObj.transform)
+					continue;
+
+				if (t.gameObject.TryGetComponent(out GamepadObjectSelector goj))
+				{
+					goj.gameObject.SetActive(false);
+				}
+			}
+
+			if (!rememberConfigPage.value)
+			{
+				if (activePanel != null && activePanel != mainPanel.gameObject)
+				{
+					if (activePanel.TryGetComponent(out ConfigPanelComponent comp))
+					{
+						if (comp.panel != null)
+							comp.panel.rootConfig.FlushAll();
+						else
+							Debug.LogWarning("Panel component does not have a config panel attached, could not flush");
+					}
+					else
+					{
+						Debug.LogWarning("Could not find panel's component");
+					}
+
+					activePanel.SetActive(false);
+				}
+				activePanel = null;
+				mainPanel.gameObject.SetActive(true);
+			}
+			else
+			{
+				if (activePanel != null) 
+					activePanel.SetActive(true);
+				else 
+					mainPanel.gameObject.SetActive(true);
+			}
+		}
 
 		private IEnumerator loadObjectAsync(Transform panel)
 		{
@@ -184,14 +235,12 @@ namespace PluginConfig
             Transform pages = optionsMenu.transform.Find("Pages");
             backButton = optionsMenu.transform.Find("Navigation Rail/Back").GetComponent<Button>();
 
-			GameObject pluginConfigObj = Addressables.InstantiateAsync(ASSET_PATH_CONFIG_BUTTON, panel).WaitForCompletion();
+			pluginConfigObj = Addressables.InstantiateAsync(ASSET_PATH_CONFIG_BUTTON, panel).WaitForCompletion();
             pluginConfigObj.SetActive(true);
 			Button pluginConfigButton = pluginConfigObj.GetComponent<Button>();
 			pluginConfigObj.transform.SetSiblingIndex(0);
-			Image buttonImage = pluginConfigObj.GetComponent<Image>();
 
-            ButtonHighlightParent highlightParent = panel.GetComponent<ButtonHighlightParent>();
-			pluginConfigButton.onClick.AddListener(() => highlightParent.ChangeButton(buttonImage));
+			pluginConfigButton.onClick.AddListener(SelectPluginConfigInOptions);
 
 			mainPanel = Addressables.InstantiateAsync(ASSET_PATH_CONFIG_PANEL, pages).WaitForCompletion().GetComponent<ConfigPanelConcrete>();
 			mainPanel.gameObject.AddComponent<MainPanelComponent>();
@@ -204,12 +253,7 @@ namespace PluginConfig
 				if (t == mainPanel.transform || t == pluginConfigObj.transform)
 					continue;
 
-				if (t.gameObject.TryGetComponent(out GamepadObjectSelector goj))
-				{
-					// Plugin config button disables all menu panels
-					pluginConfigButton.onClick.AddListener(() => goj.gameObject.SetActive(false));
-				}
-				else if (t.gameObject.TryGetComponent(out Button btn))
+				if (t.gameObject.TryGetComponent(out Button btn))
 				{
 					// Side buttons close all configuration panels
 					btn.onClick.AddListener(() =>
@@ -225,29 +269,6 @@ namespace PluginConfig
 				}
 			}
 
-			pluginConfigButton.onClick.AddListener(() =>
-			{
-				if (activePanel != null && activePanel != mainPanel.gameObject)
-				{
-					if(activePanel.TryGetComponent(out ConfigPanelComponent comp))
-					{
-						if (comp.panel != null)
-							comp.panel.rootConfig.FlushAll();
-						else
-							Debug.LogWarning("Panel component does not have a config panel attached, could not flush");
-					}
-					else
-					{
-                        Debug.LogWarning("Could not find panel's component");
-					}
-
-					activePanel.SetActive(false);
-				}
-				activePanel = null;
-
-				mainPanel.gameObject.SetActive(true);
-			});
-
 			CreateConfigUI(optionsMenu);
 			mainPanel.rect.normalizedPosition = new Vector2(0, 1);
 			NotificationPanel.InitUI();
@@ -256,6 +277,9 @@ namespace PluginConfig
 		internal static Harmony configuratorPatches;
 
 		internal static PluginConfigurator config;
+
+		internal static KeyCodeField toggleConfigBind;
+		internal static BoolField rememberConfigPage;
 
 		internal static BoolField patchCheatKeys;
 		internal static BoolField patchPause;
@@ -664,6 +688,8 @@ namespace PluginConfig
 			patchPause = new BoolField(config.rootPanel, "Patch unpause", "unpausePatch", true);
 			new ConfigSpace(config.rootPanel, 10f);
 			new ConfigHeader(config.rootPanel, "Behaviour").textColor = new Color(250 / 255f, 160 / 255f, 160 / 255f);
+			toggleConfigBind = new KeyCodeField(config.rootPanel, "Open plugin config", "toggleConfigBind", KeyCode.RightBracket);
+			rememberConfigPage = new BoolField(config.rootPanel, "Remember last config page", "rememberConfigPage", false);
 			cancelOnEsc = new BoolField(config.rootPanel, "Cancel on ESC", "cancelOnEsc", false);
             new ConfigSpace(config.rootPanel, 10f);
             new ConfigHeader(config.rootPanel, "Notification Panel").textColor = new Color(250 / 255f, 160 / 255f, 160 / 255f);
@@ -754,6 +780,26 @@ namespace PluginConfig
 			Debug.LogError($"Plugin configurator controller instance destroyed in scene '{SceneManager.GetActiveScene().name}'");
 			Debug.LogError($"Plugin was in scene '{gameObject.scene.name}'");
 			Debug.LogError($"Object name was '{gameObject.name}'");
+		}
+
+		private void Update()
+		{
+			if (Input.GetKeyDown(toggleConfigBind.value))
+			{
+				if (activePanel != null && activePanel.activeInHierarchy)
+				{
+					activePanel.SetActive(false); // Idk why but gotta do this for CloseOptions to work
+					OptionsManager.Instance.CloseOptions();
+					OptionsManager.Instance.UnPause();
+					activePanel.SetActive(true); // Revert the above SetActive or we'll get a blank screen when entering options
+				}
+				else
+				{
+					OptionsManager.Instance.Pause();
+					OptionsManager.Instance.OpenOptions();
+					SelectPluginConfigInOptions();
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Why

Configgy is nice how its menu can be opened to adjust settings at any point without having to go through the options menu every time. This PR adds that to PluginConfigurator

## What

- Added keybind `toggleConfigBind` to open/close Plugin Config. Defaults to `]` (RightBracket) because it's next to `\` (Backslash), Configgy's equivalent
- Added config option `rememberConfigPage` to remember last opened page. Defaults to false to match original behavior but can be turned on if the user wants the same experience as with Configgy

## Comments

- I also renamed some `field`s to `cfield` because `field` is now a C# keyword. Not fixing these would make compilation fail.
- The "plugin config" button's action was refactored to a new `SelectPluginConfigInOptions` so I can call it in the opening keybind, as clicking the button from there (with `.onClick.Invoke()`) doesn't seem to work. Maybe a race condition with the menu opening animation...
- I'm not sure why but `OptionsManager.Instance.CloseOptions();` to close the option menu doesn't seem to work unless I also close the `activePanel` first, so for now i have those lines 791 and 794 in `PluginConfiguratorController.cs`
- For each scene, pressing the keybind before opening the options menu for the first time would give an error like below and the menu will only open to the vanilla options menu and not reach PluginConfig. Pressing the keybind again will open PluginConfig successfully. Looks like a race condition with the initialization of the menu/button but I'm not sure how to fix that.
```
[Error  : Unity Log] NullReferenceException: Object reference not set to an instance of an object
Stack trace: 
ButtonHighlightParent.ChangeButton (UnityEngine.UI.Image target) (at <e51acc224003413ab08426f735246699>:0)
``` 
